### PR TITLE
tech: prevent 404 upon accessing via index file

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,6 +480,15 @@
             themeable: {
                 responsiveTables: false
             }
+        };
+
+        // @HACK: attempt to prevent 404 content when being open on local or via index.html, without proper SPA path routing, caused by `history` routerMode; by using `hash` routerMode.
+        if( document.location.href.endsWith('/index.html') ||
+            document.location.href.includes('/index.html#') ){
+            let currentFolderPath = (document.location.href.split('/index.html'))[0];
+            window.$docsify.basePath = currentFolderPath;
+            window.willUseDocsifyHashRouter = 1;
+            window.$docsify.routerMode = 'hash';
         }
     </script>
     <!-- Mixpanel -->


### PR DESCRIPTION
- can't be included in abs to rel, because different use case and it have to be executed before docsify lib imported