### PR TITLE
content: replace POS guide with QRIS pay type

### DIFF
--- a/en/technical-reference/docs-changelog.md
+++ b/en/technical-reference/docs-changelog.md
@@ -8,6 +8,7 @@
 - update gopay notif sample
 - update golang library link to new version
 - further explains what kind of data flow need to be verified, notification page
+- update POS integration guide, to use newer QRIS payment type
 
 #### 2021/06/11
 - faq: add woocommerce frontend popup payment page issue


### PR DESCRIPTION
- previously was using Gopay pay type.
- QRIS pay type have better qr_string API response to be used by merchant if they want to render QR themself